### PR TITLE
Fix ethical frameworks link

### DIFF
--- a/ethics/README.md
+++ b/ethics/README.md
@@ -8,7 +8,7 @@ This is an [open source project](https://github.com/TheLucasMoore/consensual_sof
 This [book](https://www.amazon.com/gp/product/0312141041/ref=oh_aui_search_detailpage?ie=UTF8&psc=1) discusses engineering ethics. <br>
 *h/t [Lisa](https://twitter.com/niftynei) who sent this to me*
 
-### [Three Ethical Frameworks]((http://coursedev.citl.mun.ca/educ2740/the-nature-of-ethics/topic-2/))
+### [Three Ethical Frameworks](http://coursedev.citl.mun.ca/educ2740/the-nature-of-ethics/topic-2/)
 Whether we're conscious of it or not, we make decisions using ethical frameworks. This is important to recognize because different frameworks can lead us to different, yet equally valid conclusions. This article covers deontological, utilitarian, and virtue-based ethics.<br>
 h/t [Ben Ng](https://twitter.com/_benng)
 


### PR DESCRIPTION
I just realized that I goofed the markdown so the link doesn't work. Oops.